### PR TITLE
Feat: Precheck if Ory Cli Installed

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "printWidth": 120,
+    "singleQuote": true,
+    "arrowParens": "always",
+    "quoteProps": "consistent",
+    "trailingComma": "none"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "eslint": "^8.36.0",
         "glob": "^8.1.0",
         "mocha": "^10.2.0",
+        "prettier": "2.8.7",
         "ts-loader": "^9.4.2",
         "typescript": "^4.9.5",
         "webpack": "^5.76.3",
@@ -2566,6 +2567,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/process-nextick-args": {
@@ -5332,6 +5348,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
       "dev": true
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -9,17 +9,27 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onCommand: ory.activate"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
       {
         "command": "ory.helloWorld",
-        "title": "Hello World"
+        "title": "Ory: Hello World"
       },
       {
         "command": "ory.version",
-        "title": "Ory Version"
+        "title": "Ory: Version"
+      },
+      {
+        "command": "ory.promptforinstall",
+        "title": "Ory: Install Cli"
+      },
+      {
+        "command": "ory.activate",
+        "title": "Ory: Activate"
       }
     ]
   },
@@ -32,22 +42,24 @@
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
-    "test": "node ./out/test/runTest.js"
+    "test": "node ./out/test/runTest.js",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" --config ./.prettierrc"
   },
   "devDependencies": {
-    "@types/vscode": "^1.77.0",
     "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.1",
     "@types/node": "16.x",
+    "@types/vscode": "^1.77.0",
     "@typescript-eslint/eslint-plugin": "^5.56.0",
     "@typescript-eslint/parser": "^5.56.0",
+    "@vscode/test-electron": "^2.3.0",
     "eslint": "^8.36.0",
     "glob": "^8.1.0",
     "mocha": "^10.2.0",
-    "typescript": "^4.9.5",
+    "prettier": "2.8.7",
     "ts-loader": "^9.4.2",
+    "typescript": "^4.9.5",
     "webpack": "^5.76.3",
-    "webpack-cli": "^5.0.1",
-    "@vscode/test-electron": "^2.3.0"
+    "webpack-cli": "^5.0.1"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,39 +1,42 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import * as vscode from "vscode";
-import { exec } from "child_process";
+import * as vscode from 'vscode';
+import { exec } from 'child_process';
+import { offerToInstallOry } from './installOry';
 
+export const outputChannel = vscode.window.createOutputChannel('Ory');
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
   // Use the console to output diagnostic information (console.log) and errors (console.error)
   // This line of code will only be executed once when your extension is activated
   console.log('Congratulations, your extension "ory" is now active!');
 
+  offerToInstallOry();
   // The command has been defined in the package.json file
   // Now provide the implementation of the command with registerCommand
   // The commandId parameter must match the command field in package.json
-  let disposableHelloWorld = vscode.commands.registerCommand(
-    "ory.helloWorld",
-    () => {
-      // The code you place here will be executed every time your command is executed
-      vscode.window.showInformationMessage("Hello World from ory!");
-    }
-  );
-  let disposableOryVersion = vscode.commands.registerCommand(
-    "ory.version",
-    () => {
-      runOryVersion();
-    }
-  );
-  context.subscriptions.push(disposableHelloWorld, disposableOryVersion);
+  let disposableHelloWorld = vscode.commands.registerCommand('ory.helloWorld', () => {
+    // The code you place here will be executed every time your command is executed
+    vscode.window.showInformationMessage('Hello World from ory!');
+  });
+  let disposableOryVersion = vscode.commands.registerCommand('ory.version', () => {
+    runOryVersion();
+  });
+  let disposableOryActivate = vscode.commands.registerCommand('ory.activate', () => {
+    vscode.window.showInformationMessage('Ory is activated');
+  });
+  let disposableOryInstall = vscode.commands.registerCommand('ory.promptforinstall', () => {
+    offerToInstallOry();
+  });
+  context.subscriptions.push(disposableHelloWorld, disposableOryVersion, disposableOryActivate, disposableOryInstall);
 }
 
 // This method is called when your extension is deactivated
 export function deactivate() {}
 
 function runOryVersion() {
-  exec("ory version", (error: Error | null, stdout: string, stderr: string) => {
+  exec('ory version', (error: Error | null, stdout: string, stderr: string) => {
     if (error) {
       console.log(`error: ${error.message}`);
       return;
@@ -43,7 +46,7 @@ function runOryVersion() {
       return;
     }
     vscode.window.showInformationMessage(`${stdout}`, {
-      modal: true,
+      modal: true
     });
   });
 }

--- a/src/installOry.ts
+++ b/src/installOry.ts
@@ -1,0 +1,187 @@
+import { exec } from 'child_process';
+import * as vscode from 'vscode';
+import * as os from 'os';
+import { outputChannel } from './extension';
+
+let alreadyOfferedToInstallOry = false;
+
+export async function offerToInstallOry() {
+  outputChannel.clear();
+  if (alreadyOfferedToInstallOry) {
+    vscode.window.showInformationMessage('Ory Cli is already installed.');
+    return;
+  }
+
+  await runCommand('ory version')
+    .then((result) => {
+      console.log(result);
+      alreadyOfferedToInstallOry = true;
+    })
+    .catch((err) => {
+      console.error(err);
+      outputChannel.appendLine(err);
+      const installItem = {
+        title: 'Install',
+        async command() {
+          // Install ory cli
+          console.log('Installing ory');
+          outputChannel.appendLine('Installing Ory Cli...');
+          installOryCli();
+        }
+      };
+      const checkDoc = {
+        title: 'Check Docs',
+        command() {
+          vscode.env.openExternal(vscode.Uri.parse('https://www.ory.sh/docs/guides/cli/installation'));
+        }
+      };
+      vscode.window
+        .showInformationMessage('Failed to find Ory CLI. Would you like to install Ory CLI?', installItem, checkDoc)
+        .then((selection) => {
+          if (selection) {
+            selection.command();
+          }
+        });
+    });
+}
+
+async function installOryCli() {
+  switch (os.platform()) {
+    case 'darwin':
+      await runCommand('brew install ory/tap/cli')
+        .then((result) => {
+          alreadyOfferedToInstallOry = true;
+          console.log('Ory Cli install successfully. ' + result);
+          outputChannel.appendLine('Ory Cli install successfully. ' + result);
+        })
+        .catch((err) => {
+          console.error(err);
+          let errString = err.message;
+          outputChannel.appendLine(err);
+          if (errString.includes('-bash: brew: command not found')) {
+            const installItem = {
+              title: 'Install Brew',
+              command() {
+                runCommand(
+                  '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+                )
+                  .then((result) => {
+                    console.log('Brew install successfully. ' + result);
+                    vscode.window.showInformationMessage('Brew was installed successfully!');
+                    outputChannel.appendLine('Brew was installed successfully!');
+                    offerToInstallOry();
+                  })
+                  .catch((err) => {
+                    console.error(err);
+                    outputChannel.appendLine(err);
+                  });
+              }
+            };
+            const checkDoc = {
+              title: 'Check Docs',
+              command() {
+                vscode.env.openExternal(vscode.Uri.parse('https://www.ory.sh/docs/guides/cli/installation#macos'));
+              }
+            };
+            vscode.window
+              .showErrorMessage('Failed to run brew. Would you like to install brew?', installItem, checkDoc)
+              .then((selection) => {
+                if (selection) {
+                  selection.command();
+                }
+              });
+          }
+        });
+      break;
+    case 'linux':
+      await runCommand(
+        "bash -c 'bash <(curl https://raw.githubusercontent.com/ory/meta/master/install.sh) -b . ory && mv ./ory /usr/local/bin/'"
+      )
+        .then((result) => {
+          alreadyOfferedToInstallOry = true;
+          console.log('Ory Cli install successfully');
+          outputChannel.appendLine('Ory Cli install successfully');
+        })
+        .catch((err) => {
+          console.error(err);
+          var errString = err.message;
+          if (errString.includes('ory/ info installed ./ory')) {
+            vscode.window.showInformationMessage('Ory Cli was installed successfully!');
+          }
+          outputChannel.appendLine(err);
+        });
+      break;
+    case 'win32':
+      await runCommand('scoop bucket add ory https://github.com/ory/scoop.git && scoop install ory')
+        .then((result) => {
+          alreadyOfferedToInstallOry = true;
+          console.log('Ory Cli install successfully. ' + result);
+          let oryVersionMessage = result.split('\n');
+          if (oryVersionMessage[oryVersionMessage.length - 1] === '') {
+            vscode.window.showInformationMessage(oryVersionMessage[oryVersionMessage.length - 2]);
+          } else {
+            vscode.window.showInformationMessage('Ory Cli was installed successfully!');
+          }
+          outputChannel.appendLine('Ory Cli install successfully');
+        })
+        .catch((err) => {
+          console.error(err.message);
+          var errString = err.message;
+          outputChannel.appendLine(err.message);
+          if (errString.includes(`'scoop' is not recognized as an internal or external command`)) {
+            const installItem = {
+              title: 'Install Scoop',
+              command() {
+                runCommand(
+                  'powershell -command "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser; irm get.scoop.sh | iex"'
+                )
+                  .then((result) => {
+                    console.log('Scoop install successfully. ' + result);
+                    vscode.window.showInformationMessage('scoop was installed successfully!');
+                    outputChannel.appendLine('scoop was installed successfully!');
+                    offerToInstallOry();
+                  })
+                  .catch((err) => {
+                    console.error(err);
+                    outputChannel.appendLine(err);
+                  });
+              }
+            };
+            const checkDoc = {
+              title: 'Check Docs',
+              command() {
+                vscode.env.openExternal(vscode.Uri.parse('https://www.ory.sh/docs/guides/cli/installation#windows'));
+              }
+            };
+            vscode.window
+              .showErrorMessage('Failed to run scoop. Would you like to install scoop?', installItem, checkDoc)
+              .then((selection) => {
+                if (selection) {
+                  selection.command();
+                }
+              });
+          }
+        });
+      break;
+    default:
+      console.warn('Not able to recoginize the OS!!!');
+      outputChannel.appendLine('Not able to recoginize the OS!!!');
+      break;
+  }
+}
+
+async function runCommand(command: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    exec(`${command}`, (error: Error | null, stdout: string, stderr: string) => {
+      if (error) {
+        //   console.log(`error: ${error.message}`);
+        reject(new Error(`${error.message}`));
+      }
+      if (stderr) {
+        //   console.log(`stderr: ${stderr}`);
+        reject(new Error(`${stderr}`));
+      }
+      resolve(stdout);
+    });
+  });
+}

--- a/src/installOry.ts
+++ b/src/installOry.ts
@@ -165,7 +165,7 @@ async function installOryCli() {
       break;
     default:
       console.warn('Not able to recognize the OS!');
-      outputChannel.appendLine('Not able to recoginize the OS!!!');
+      outputChannel.appendLine('Not able to recognize the OS!');
       break;
   }
 }

--- a/src/installOry.ts
+++ b/src/installOry.ts
@@ -164,7 +164,7 @@ async function installOryCli() {
         });
       break;
     default:
-      console.warn('Not able to recoginize the OS!!!');
+      console.warn('Not able to recognize the OS!');
       outputChannel.appendLine('Not able to recoginize the OS!!!');
       break;
   }


### PR DESCRIPTION
In this case, when the user activates the extension, it will first check to see if the system has Ory CLI installed; if it does not, it will give the user the option to install it from the Vs Code with Information message. Based on OS, it will install Ory CLI with checking pre-requisites for CLI tools like Scoop, Brew,... If it doesn't have pre-requisites, also give the option to install Scoop and Brew.

![image](https://user-images.githubusercontent.com/35197703/230590924-b9ec2327-7267-438a-aafc-663fe987efd8.png)
