### PR TITLE
Feat: Ory Delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,21 @@
           "command": "ory.copy.identityID",
           "when": "view == listIdentities",
           "group": "identities_1_general@2"
+        },
+        {
+          "command": "ory.copy.relationshipString",
+          "when": "view == listRelationships",
+          "group": "relationships_1_general@1"
+        },
+        {
+          "command": "ory.delete.identity",
+          "when": "view == listIdentities && viewItem == identity",
+          "group": "inline"
+        },
+        {
+          "command": "ory.delete.oauth2Client",
+          "when": "view == listOauth2Clients && viewItem == oauth2Clients",
+          "group": "inline"
         }
       ]
     },
@@ -173,6 +188,20 @@
         "title": "Get Identity"
       },
       {
+        "command": "ory.delete",
+        "title": "Ory: Delete"
+      },
+      {
+        "command": "ory.delete.identity",
+        "title": "Delete Identity",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "ory.delete.oauth2Client",
+        "title": "Delete Oauth2-Client",
+        "icon": "$(trash)"
+      },
+      {
         "command": "ory.projects.refresh",
         "title": "Refresh",
         "icon": "$(refresh)"
@@ -191,6 +220,10 @@
         "command": "ory.relationships.refresh",
         "title": "Refresh",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "ory.copy.relationshipString",
+        "title": "Copy Relationship String"
       },
       {
         "command": "ory.use",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,8 @@ import * as os from 'os';
 import { runOryUse, runOryUseProject } from './oryUse';
 import { IdentitiesTreeItem, ListIdentitiesProvider } from './tree/listIdentities';
 import { ListOauth2ClientsProvider, Oauth2ClientsTreeItem } from './tree/listOauth2Clients';
-import { ListRelationshipsProvider } from './tree/listRelationships';
+import { ListRelationshipsProvider, RelationshipsTreeItem } from './tree/listRelationships';
+import { runOryDelete } from './oryDelete';
 import { runOryCreate } from './oryCreate';
 
 export const outputChannel = vscode.window.createOutputChannel('Ory');
@@ -61,14 +62,14 @@ export async function activate(context: vscode.ExtensionContext) {
     treeDataProvider: listOauth2ClientsProvider
   });
 
-    // Oauth2-Clients List
-    const listRelationshipsProvider = new ListRelationshipsProvider();
-    vscode.window.registerTreeDataProvider('listRelationships', listRelationshipsProvider);
-    registerCommand('ory.relationships.refresh', () => listRelationshipsProvider.refresh(), context);
-    const relationshipsView = vscode.window.createTreeView('listRelationships', {
-      treeDataProvider: listRelationshipsProvider,
-      showCollapseAll: true
-    });
+  // Oauth2-Clients List
+  const listRelationshipsProvider = new ListRelationshipsProvider();
+  vscode.window.registerTreeDataProvider('listRelationships', listRelationshipsProvider);
+  registerCommand('ory.relationships.refresh', () => listRelationshipsProvider.refresh(), context);
+  const relationshipsView = vscode.window.createTreeView('listRelationships', {
+    treeDataProvider: listRelationshipsProvider,
+    showCollapseAll: true
+  });
 
   registerCommand('ory.helloWorld', () => vscode.window.showInformationMessage('Hello World from ory!'), context);
   registerCommand('ory.version', () => runOryVersion(), context);
@@ -194,6 +195,31 @@ export async function activate(context: vscode.ExtensionContext) {
     },
     context
   );
+  registerCommand(
+    'ory.copy.relationshipString',
+    async (node?: RelationshipsTreeItem) => {
+      console.log(node?.relationshipString);
+      if (node !== undefined) {
+        vscode.env.clipboard
+          .writeText(node.relationshipString)
+          .then(() => vscode.window.showInformationMessage('Copied to clipboard!'));
+      }
+    },
+    context
+  );
+  registerCommand('ory.delete', () => runOryDelete(), context);
+  registerCommand('ory.delete.identity',async (node?:IdentitiesTreeItem) => { 
+    console.log(node?.iId);
+    if (node !== undefined) {
+      listIdentitiesProvider.delete(node.iId);
+    }
+  }, context);
+  registerCommand('ory.delete.oauth2Client',async (node?:Oauth2ClientsTreeItem) => { 
+    console.log(node?.clientID);
+    if (node !== undefined) {
+      listOauth2ClientsProvider.delete(node.clientID);
+    }
+  }, context);
   context.subscriptions.push(projectView, identityView, oauth2ClientsView, relationshipsView);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -208,18 +208,26 @@ export async function activate(context: vscode.ExtensionContext) {
     context
   );
   registerCommand('ory.delete', () => runOryDelete(), context);
-  registerCommand('ory.delete.identity',async (node?:IdentitiesTreeItem) => { 
-    console.log(node?.iId);
-    if (node !== undefined) {
-      listIdentitiesProvider.delete(node.iId);
-    }
-  }, context);
-  registerCommand('ory.delete.oauth2Client',async (node?:Oauth2ClientsTreeItem) => { 
-    console.log(node?.clientID);
-    if (node !== undefined) {
-      listOauth2ClientsProvider.delete(node.clientID);
-    }
-  }, context);
+  registerCommand(
+    'ory.delete.identity',
+    async (node?: IdentitiesTreeItem) => {
+      console.log(node?.iId);
+      if (node !== undefined) {
+        listIdentitiesProvider.delete(node.iId);
+      }
+    },
+    context
+  );
+  registerCommand(
+    'ory.delete.oauth2Client',
+    async (node?: Oauth2ClientsTreeItem) => {
+      console.log(node?.clientID);
+      if (node !== undefined) {
+        listOauth2ClientsProvider.delete(node.clientID);
+      }
+    },
+    context
+  );
   context.subscriptions.push(projectView, identityView, oauth2ClientsView, relationshipsView);
 }
 

--- a/src/helper/index.ts
+++ b/src/helper/index.ts
@@ -79,15 +79,21 @@ export function webViewPanel(viewType: string, title: string, showOptions: vscod
   panel.webview.html = htmlContent;
 }
 
-export async function commandInput(obj: { label: string; description: string; type: string }): Promise<string[]> {
+export async function commandInput(obj: { label: string; description: string; type: string; useLabelPlaceHolder?: boolean; }): Promise<string[]> {
   let resultString: string[] = [];
-  let input = await vscode.window.showInputBox({
-    title: obj.label,
-    placeHolder:
-      obj.type === 'string' ? 'Enter project id' : 'Enter multiple inputs "," (comma-separated). ex- id-1, id-2',
-    prompt: obj.description,
-    ignoreFocusOut: true
-  });
+  let input: string | undefined;
+  if (obj.type === 'empty') {
+    input = '';
+  } else {
+    let placeHolder = obj.useLabelPlaceHolder ? obj.label : 'Project ID';
+    input = await vscode.window.showInputBox({
+      title: obj.label,
+      placeHolder:
+        obj.type === 'string' ? `Enter ${placeHolder}` : 'Enter multiple inputs "," (comma-separated). ex- id-1, id-2',
+      prompt: obj.description,
+      ignoreFocusOut: true
+    });
+  }
 
   if (input === undefined) {
     throw new Error('Invalid input');

--- a/src/helper/index.ts
+++ b/src/helper/index.ts
@@ -2,21 +2,21 @@ import * as vscode from 'vscode';
 import { ChildProcessWithoutNullStreams } from 'child_process';
 import { outputChannel } from '../extension';
 
-export async function spwanCommonErrAndClose(
+export async function spawnCommonErrAndClose(
   spawnObj: ChildProcessWithoutNullStreams,
-  compoenetName: string,
+  componentName: string,
   format?: string
 ): Promise<string> {
   return new Promise((resolve, reject) => {
-    let cmdOuput: string = '';
+    let cmdOutput: string = '';
     spawnObj.stdout.on('data', (data) => {
       outputChannel.append('\n' + String(data));
       console.log(`stdout: ${data}`);
       if (format !== '' && format !== undefined) {
         let jsonOrYamlExt: string = format?.includes('json') ? 'json' : 'yaml';
-        webViewPanel(compoenetName + 'Panel', compoenetName + '-' + jsonOrYamlExt, vscode.ViewColumn.Beside, data);
+        webViewPanel(componentName + 'Panel', componentName + '-' + jsonOrYamlExt, vscode.ViewColumn.Beside, data);
       }
-      cmdOuput += String(data);
+      cmdOutput += String(data);
     });
 
     spawnObj.stderr.on('data', (data) => {
@@ -39,14 +39,14 @@ export async function spwanCommonErrAndClose(
       if (data.includes('Error: no project was specified')) {
         vscode.window.showErrorMessage('No project id was specified');
       } else {
-        vscode.window.showErrorMessage('Opps 🫢 something went wrong! Please check in Output -> Ory');
+        vscode.window.showErrorMessage('Oops 🫢 something went wrong! Please check in Output -> Ory');
       }
     });
 
     spawnObj.on('close', (code) => {
       outputChannel.append(`\nprocess exited with code ${code}`);
       console.log(`child process exited with code ${code}`);
-      resolve(cmdOuput.trim());
+      resolve(cmdOutput.trim());
     });
   });
 }
@@ -77,4 +77,29 @@ export function webViewPanel(viewType: string, title: string, showOptions: vscod
           </html>
           `;
   panel.webview.html = htmlContent;
+}
+
+export async function commandInput(obj: { label: string; description: string; type: string }): Promise<string[]> {
+  let resultString: string[] = [];
+  let input = await vscode.window.showInputBox({
+    title: obj.label,
+    placeHolder:
+      obj.type === 'string' ? 'Enter project id' : 'Enter multiple inputs "," (comma-separated). ex- id-1, id-2',
+    prompt: obj.description,
+    ignoreFocusOut: true
+  });
+
+  if (input === undefined) {
+    throw new Error('Invalid input');
+  }
+
+  if (obj.type === 'strings') {
+    // (?:,|s)s*
+    input = input.replace(RegExp('(?:,\\s)s*'), ',');
+    resultString = input.split(',');
+  } else {
+    resultString.push(input);
+  }
+
+  return resultString;
 }

--- a/src/oryAuth.ts
+++ b/src/oryAuth.ts
@@ -189,7 +189,7 @@ function oryAuthHelper(
     }
   });
 
-  // Any Errors 
+  // Any Errors
   ptyProcess.onExit((e: any) => {
     outputChannel.append(e);
     console.error(e);
@@ -203,7 +203,7 @@ export async function runOryAuthLogout() {
   ls.stdout.on('data', (data) => {
     outputChannel.append('\n' + String(data));
     console.log(`stdout: ${data}`);
-    vscode.window.showInformationMessage("You signed out successfully ☹️");
+    vscode.window.showInformationMessage('You signed out successfully ☹️');
   });
 
   ls.stderr.on('data', (data) => {

--- a/src/oryCreate.ts
+++ b/src/oryCreate.ts
@@ -117,13 +117,16 @@ export async function runOryCreate() {
       console.log(`Got: oauth2-client`);
 
       let oauth2ClientOptions: string[] = [];
-      await oauth2Client().then((value) => {
-        if (value.length === 0) {
-          vscode.window.showInformationMessage('creating oauth2-client with default values.');
-          console.log('creating oauth2-client with default values.');
+      oauth2ClientOptions = await oauth2Client();
+      if (oauth2ClientOptions.length === 0) {
+        const quit = await vscode.window.showInputBox({title: 'Do you want to quit oauth2-client creation?',placeHolder: '[y/n]', ignoreFocusOut: true});
+        if (quit?.toLowerCase() === 'y' || quit === undefined){
+          return;
         }
-        oauth2ClientOptions = value;
-      });
+        vscode.window.showInformationMessage('creating oauth2-client with default values.');
+        console.log('creating oauth2-client with default values.');
+      }
+      
       console.log('This oauth2client: ' + oauth2ClientOptions);
       const createOauth2Client = spawn(oryCommand, ['create', 'oauth2-client', ...oauth2ClientOptions]);
 

--- a/src/oryCreate.ts
+++ b/src/oryCreate.ts
@@ -119,14 +119,18 @@ export async function runOryCreate() {
       let oauth2ClientOptions: string[] = [];
       oauth2ClientOptions = await oauth2Client();
       if (oauth2ClientOptions.length === 0) {
-        const quit = await vscode.window.showInputBox({title: 'Do you want to quit oauth2-client creation?',placeHolder: '[y/n]', ignoreFocusOut: true});
-        if (quit?.toLowerCase() === 'y' || quit === undefined){
+        const quit = await vscode.window.showInputBox({
+          title: 'Do you want to quit oauth2-client creation?',
+          placeHolder: '[y/n]',
+          ignoreFocusOut: true
+        });
+        if (quit?.toLowerCase() === 'y' || quit === undefined) {
           return;
         }
         vscode.window.showInformationMessage('creating oauth2-client with default values.');
         console.log('creating oauth2-client with default values.');
       }
-      
+
       console.log('This oauth2client: ' + oauth2ClientOptions);
       const createOauth2Client = spawn(oryCommand, ['create', 'oauth2-client', ...oauth2ClientOptions]);
 
@@ -277,7 +281,7 @@ export async function runOryCreate() {
       const relationshipConfigFileInput = await vscode.window.showOpenDialog({
         title: 'Ory Create Relationships',
         canSelectMany: false,
-        filters: { "json": ['json']}
+        filters: { json: ['json'] }
       });
 
       if (relationshipConfigFileInput === undefined) {
@@ -285,7 +289,11 @@ export async function runOryCreate() {
         return;
       }
       console.log(relationshipConfigFileInput[0].fsPath);
-      const createRelationships = spawn(oryCommand, ['create', 'relationships', `${relationshipConfigFileInput[0].fsPath}`]);
+      const createRelationships = spawn(oryCommand, [
+        'create',
+        'relationships',
+        `${relationshipConfigFileInput[0].fsPath}`
+      ]);
 
       createRelationships.stdout.on('data', (data) => {
         outputChannel.append('\n' + String(data));

--- a/src/oryDelete.ts
+++ b/src/oryDelete.ts
@@ -221,7 +221,7 @@ export async function oryDeleteRelationships() {
       title: 'View Details',
       details() {
         let processString = rsp;
-        processString.replace('\t','\t\t');
+        processString = processString.replace(/\t(?!\n)/g," |  ");
         vscode.window.showInformationMessage('Warning: ', {
           modal: true,
           detail: `${processString}`

--- a/src/oryDelete.ts
+++ b/src/oryDelete.ts
@@ -75,7 +75,6 @@ export async function runOryDelete() {
 
       break;
     case 'relationships':
-
       oryDeleteRelationships();
 
       break;
@@ -205,7 +204,7 @@ export async function oryDeleteRelationships() {
   console.log('Flag values: ' + flagsValue);
   let stringBuilder: string[] = [];
   flagsValue.forEach((value: string, key: string) => {
-    if (key === 'all' || key === 'force' ) {
+    if (key === 'all' || key === 'force') {
       stringBuilder.push('--' + key);
     } else {
       stringBuilder.push('--' + key + '=' + value);
@@ -215,20 +214,20 @@ export async function oryDeleteRelationships() {
   const deleteRelationships = spawn(oryCommand, ['delete', 'relationships', ...stringBuilder]);
 
   const rsp = await spawnCommonErrAndClose(deleteRelationships, 'relationships', '');
-  if(rsp.includes("WARNING")){
+  if (rsp.includes('WARNING')) {
     let warnData = rsp.trim().split('\n');
     const viewDetails = {
       title: 'View Details',
       details() {
         let processString = rsp;
-        processString = processString.replace(/\t(?!\n)/g," |  ");
+        processString = processString.replace(/\t(?!\n)/g, ' |  ');
         vscode.window.showInformationMessage('Warning: ', {
           modal: true,
           detail: `${processString}`
         });
       }
     };
-    vscode.window.showWarningMessage(warnData[0]+' '+ warnData[1], viewDetails).then((selection) => {
+    vscode.window.showWarningMessage(warnData[0] + ' ' + warnData[1], viewDetails).then((selection) => {
       if (selection) {
         selection.details();
       }

--- a/src/oryDelete.ts
+++ b/src/oryDelete.ts
@@ -1,0 +1,147 @@
+import * as vscode from 'vscode';
+import { spawn } from 'child_process';
+import { outputChannel, oryCommand } from './extension';
+import { spawnCommonErrAndClose, commandInput } from './helper';
+
+export async function runOryDelete() {
+  const result = await vscode.window.showQuickPick(
+    [
+      { label: 'identity', description: 'Delete one or more identities by their ID(s)', type: 'strings' },
+      { label: 'access-tokens', description: 'Delete all OAuth2 Access Tokens of an OAuth2 Client', type: 'string' },
+      { label: 'jwk', description: 'Delete one or more JSON Web Key Sets by their set ID', type: 'strings' },
+      { label: 'oauth2-client', description: 'Delete one or more OAuth 2.0 Clients by their ID(s)', type: 'strings' },
+      { label: 'relationships', description: 'Delete ALL relation tuples matching the relation query.', type: 'string' }
+    ],
+    { placeHolder: 'Pick to get resource...', title: 'Ory Delete', ignoreFocusOut: true }
+  );
+  switch (result?.label) {
+    case 'identity':
+      let identityDeleteCmdOutput: string[] = [];
+      try {
+        identityDeleteCmdOutput = await commandInput(result);
+        console.log(identityDeleteCmdOutput);
+      } catch (err: any) {
+        console.error(`[${result?.label}] Error: ${err.message}`);
+        outputChannel.append(`[${result?.label}] Error: ${err.message}`);
+        return;
+      }
+
+      oryDeleteIdentity(identityDeleteCmdOutput);
+
+      break;
+    case 'access-tokens':
+      let accessTokenCmdOutput: string[] = [];
+
+      try {
+        accessTokenCmdOutput = await commandInput(result);
+        console.log(accessTokenCmdOutput);
+      } catch (err: any) {
+        console.error(`[${result?.label}] Error: ${err.message}`);
+        outputChannel.append(`[${result?.label}] Error: ${err.message}`);
+        return;
+      }
+
+      oryDeleteAccessTokens(accessTokenCmdOutput);
+
+      break;
+    case 'jwk':
+      let jwkCmdOutput: string[] = [];
+
+      try {
+        jwkCmdOutput = await commandInput(result);
+        console.log(jwkCmdOutput);
+      } catch (err: any) {
+        console.error(`[${result?.label}] Error: ${err.message}`);
+        outputChannel.append(`[${result?.label}] Error: ${err.message}`);
+        return;
+      }
+
+      oryDeleteJWK(jwkCmdOutput);
+
+      break;
+    case 'oauth2-client':
+      let oauth2ClientCmdOutput: string[] = [];
+
+      try {
+        oauth2ClientCmdOutput = await commandInput(result);
+        console.log(oauth2ClientCmdOutput);
+      } catch (err: any) {
+        console.error(`[${result?.label}] Error: ${err.message}`);
+        outputChannel.append(`[${result?.label}] Error: ${err.message}`);
+        return;
+      }
+
+      oryDeleteOauth2Client(oauth2ClientCmdOutput);
+
+      break;
+    case 'relationships':
+      let relationshipsCmdOutput: string[] = [];
+
+      try {
+        relationshipsCmdOutput = await commandInput(result);
+        console.log(relationshipsCmdOutput);
+      } catch (err: any) {
+        console.error(`[${result?.label}] Error: ${err.message}`);
+        outputChannel.append(`[${result?.label}] Error: ${err.message}`);
+        return;
+      }
+
+      oryDeleteRelationships(relationshipsCmdOutput);
+
+      break;
+  }
+}
+
+export async function oryDeleteIdentity(identityDeleteCmdOutput: string[]): Promise<string> {
+  const deleteIdentity = spawn(oryCommand, ['delete', 'identity', ...identityDeleteCmdOutput, '--format', 'json']);
+  let result = '';
+  await spawnCommonErrAndClose(deleteIdentity, 'project', '').then((value: string) => {
+    result = value;
+  });
+  return result;
+}
+
+export async function oryDeleteAccessTokens(accessTokenCmdOutput: string[]) {
+  const deleteAccessTokens = spawn(oryCommand, [
+    'delete',
+    'access-tokens',
+    ...accessTokenCmdOutput,
+    '--format',
+    'json'
+  ]);
+
+  await spawnCommonErrAndClose(deleteAccessTokens, 'access-tokens', '');
+}
+
+export async function oryDeleteJWK(jwkCmdOutput: string[]) {
+  const deleteJwk = spawn(oryCommand, ['delete', 'jwk', ...jwkCmdOutput, '--format', 'json']);
+
+  await spawnCommonErrAndClose(deleteJwk, 'jwk', '');
+}
+
+export async function oryDeleteOauth2Client(oauth2ClientCmdOutput: string[]): Promise<string> {
+  const deleteOauth2Client = spawn(oryCommand, [
+    'delete',
+    'oauth2-client',
+    ...oauth2ClientCmdOutput,
+    '--format',
+    'json'
+  ]);
+  let result = '';
+  await spawnCommonErrAndClose(deleteOauth2Client, 'oauth2-client', '').then((value: string) => {
+    result = value;
+  });
+  return result;
+}
+
+export async function oryDeleteRelationships(relationshipsCmdOutput: string[]) {
+  const deleteRelationships = spawn(oryCommand, [
+    'delete',
+    'relationships',
+    ...relationshipsCmdOutput,
+    '--format',
+    'json'
+  ]);
+
+  await spawnCommonErrAndClose(deleteRelationships, 'relationships', '');
+}

--- a/src/oryGet.ts
+++ b/src/oryGet.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { spawn } from 'child_process';
 import { outputChannel, oryCommand } from './extension';
-import { format, spwanCommonErrAndClose, webViewPanel } from './helper';
+import { format, spawnCommonErrAndClose, commandInput } from './helper';
 
 export async function runOryGet() {
   const result = await vscode.window.showQuickPick(
@@ -147,7 +147,7 @@ export function oryGetProject(projectCommandOutput: string[], projectOutputForma
     `${projectOutputFormat}`
   ]);
 
-  spwanCommonErrAndClose(getProject, 'project', projectOutputFormat);
+  spawnCommonErrAndClose(getProject, 'project', projectOutputFormat);
 }
 
 export function oryGetPermissionConfig(permissionConfigCommandOutput: string[], permissionConfigOutputFormat: string) {
@@ -159,7 +159,7 @@ export function oryGetPermissionConfig(permissionConfigCommandOutput: string[], 
     `${permissionConfigOutputFormat}`
   ]);
 
-  spwanCommonErrAndClose(getPermissionConfig, 'permissionConfig', permissionConfigOutputFormat);
+  spawnCommonErrAndClose(getPermissionConfig, 'permissionConfig', permissionConfigOutputFormat);
 }
 
 export function oryGetOauth2Config(oauth2ConfigCommandOutput: string[], oauth2ConfigOutputFormat: string) {
@@ -171,7 +171,7 @@ export function oryGetOauth2Config(oauth2ConfigCommandOutput: string[], oauth2Co
     `${oauth2ConfigOutputFormat}`
   ]);
 
-  spwanCommonErrAndClose(getOauth2Config, 'oauth2Config', oauth2ConfigOutputFormat);
+  spawnCommonErrAndClose(getOauth2Config, 'oauth2Config', oauth2ConfigOutputFormat);
 }
 
 export function oryGetOauth2Client(oauth2ClientCommandOutput: string[], oauth2ClientOutputFormat: string) {
@@ -183,13 +183,13 @@ export function oryGetOauth2Client(oauth2ClientCommandOutput: string[], oauth2Cl
     `${oauth2ClientOutputFormat}`
   ]);
 
-  spwanCommonErrAndClose(getOauth2Client, 'oauth2Client', oauth2ClientOutputFormat);
+  spawnCommonErrAndClose(getOauth2Client, 'oauth2Client', oauth2ClientOutputFormat);
 }
 
 export function oryGetJWK(jwkConfigCommandOutput: string[], jwkConfigOutputFormat: string) {
   const getJWK = spawn(oryCommand, ['get', 'jwk', ...jwkConfigCommandOutput, '--format', `${jwkConfigOutputFormat}`]);
 
-  spwanCommonErrAndClose(getJWK, 'jwk', jwkConfigOutputFormat);
+  spawnCommonErrAndClose(getJWK, 'jwk', jwkConfigOutputFormat);
 }
 
 export function oryGetIdentityConfig(identityConfigCommandOutput: string[], identityConfigOutputFormat: string) {
@@ -201,7 +201,7 @@ export function oryGetIdentityConfig(identityConfigCommandOutput: string[], iden
     `${identityConfigOutputFormat}`
   ]);
 
-  spwanCommonErrAndClose(getIdentityConfig, 'identityConfig', identityConfigOutputFormat);
+  spawnCommonErrAndClose(getIdentityConfig, 'identityConfig', identityConfigOutputFormat);
 }
 
 export function oryGetIdentity(identityCommandOutput: string[], identityOutputFormat: string) {
@@ -213,30 +213,5 @@ export function oryGetIdentity(identityCommandOutput: string[], identityOutputFo
     `${identityOutputFormat}`
   ]);
 
-  spwanCommonErrAndClose(getIdentity, 'identity', identityOutputFormat);
-}
-
-async function commandInput(obj: { label: string; description: string; type: string }): Promise<string[]> {
-  let resultString: string[] = [];
-  let input = await vscode.window.showInputBox({
-    title: obj.label,
-    placeHolder:
-      obj.type === 'string' ? 'Enter project id' : 'Enter multiple inputs "," (comma-separated). ex- id-1, id-2',
-    prompt: obj.description,
-    ignoreFocusOut: true
-  });
-
-  if (input === undefined) {
-    throw new Error('Invalid input');
-  }
-
-  if (obj.type === 'strings') {
-    // (?:,|s)s*
-    input = input.replace(RegExp('(?:,\\s)s*'), ',');
-    resultString = input.split(',');
-  } else {
-    resultString.push(input);
-  }
-
-  return resultString;
+  spawnCommonErrAndClose(getIdentity, 'identity', identityOutputFormat);
 }

--- a/src/oryUse.ts
+++ b/src/oryUse.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { spawn } from 'child_process';
 import { outputChannel, oryCommand } from './extension';
 import { runOryListProjects } from './tree/listProjects';
-import { spwanCommonErrAndClose } from './helper';
+import { spawnCommonErrAndClose } from './helper';
 
 export async function runOryUse() {
   let projectsList: { label: string; description: string }[] = [];
@@ -27,7 +27,7 @@ export async function runOryUse() {
 export async function runOryUseProject(projectId: string, projectName?: string) {
   const useProject = spawn(oryCommand, ['use', 'project', projectId]);
 
-  await spwanCommonErrAndClose(useProject, 'useProject').then((value) => {
+  await spawnCommonErrAndClose(useProject, 'useProject').then((value) => {
     if (value.includes('ID')) {
       vscode.window.showInformationMessage(`Using Project: ${projectName}`);
     }

--- a/src/tree/listIdentities.ts
+++ b/src/tree/listIdentities.ts
@@ -64,7 +64,7 @@ export class ListIdentitiesProvider implements vscode.TreeDataProvider<Identitie
 
   async delete(id: string) {
     const val = await oryDeleteIdentity([id]);
-    if(val.includes(id)){
+    if (val.includes(id)) {
       const index = this.topLevelItems.findIndex((item) => item.iId === id);
       if (index !== -1) {
         this.topLevelItems.splice(index, 1);
@@ -82,14 +82,14 @@ export class IdentitiesTreeItem extends vscode.TreeItem {
     this.tooltip = `ID: ${identity.id}\nState: ${identity.state}\nTraits: ${identity.traits}\nSchema ID: ${identity.schemaId}\nSchema URL: ${identity.schemaUrl}`;
     this.iconPath = this.getIconPath(identity.state);
     this._item = this.identity;
-    this.contextValue = "identity";
+    this.contextValue = 'identity';
   }
 
   public get iId(): string {
     return this._item.id;
   }
 
-   public get iSchemaID(): string {
+  public get iSchemaID(): string {
     return this._item.schemaId;
   }
 

--- a/src/tree/listIdentities.ts
+++ b/src/tree/listIdentities.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import { spawn } from 'child_process';
 import { oryCommand } from '../extension';
-import { spwanCommonErrAndClose } from '../helper';
+import { spawnCommonErrAndClose } from '../helper';
+import { oryDeleteIdentity } from '../oryDelete';
 
 export interface Identity {
   id: string;
@@ -60,6 +61,17 @@ export class ListIdentitiesProvider implements vscode.TreeDataProvider<Identitie
     }
     return [];
   }
+
+  async delete(id: string) {
+    const val = await oryDeleteIdentity([id]);
+    if(val.includes(id)){
+      const index = this.topLevelItems.findIndex((item) => item.iId === id);
+      if (index !== -1) {
+        this.topLevelItems.splice(index, 1);
+        this._onDidChangeTreeData.fire();
+      }
+    }
+  }
 }
 
 export class IdentitiesTreeItem extends vscode.TreeItem {
@@ -70,13 +82,14 @@ export class IdentitiesTreeItem extends vscode.TreeItem {
     this.tooltip = `ID: ${identity.id}\nState: ${identity.state}\nTraits: ${identity.traits}\nSchema ID: ${identity.schemaId}\nSchema URL: ${identity.schemaUrl}`;
     this.iconPath = this.getIconPath(identity.state);
     this._item = this.identity;
+    this.contextValue = "identity";
   }
 
   public get iId(): string {
     return this._item.id;
   }
 
-  public get iSchemaID(): string {
+   public get iSchemaID(): string {
     return this._item.schemaId;
   }
 
@@ -114,7 +127,7 @@ export async function runOryListIdentities(): Promise<any> {
   let json: any;
 
   const listIdentities = spawn(oryCommand, ['list', 'identities', '--format', `${identitiesOutputFormat}`]);
-  await spwanCommonErrAndClose(listIdentities, 'Identities').then((value) => {
+  await spawnCommonErrAndClose(listIdentities, 'Identities').then((value) => {
     json = JSON.parse(value);
   });
   return json;

--- a/src/tree/listOauth2Clients.ts
+++ b/src/tree/listOauth2Clients.ts
@@ -68,7 +68,7 @@ export class ListOauth2ClientsProvider implements vscode.TreeDataProvider<Oauth2
 
   async delete(id: string) {
     const val = await oryDeleteOauth2Client([id]);
-    if(val.includes(id)){
+    if (val.includes(id)) {
       const index = this.topLevelItems.findIndex((item) => item.clientID === id);
       if (index !== -1) {
         this.topLevelItems.splice(index, 1);
@@ -86,7 +86,7 @@ export class Oauth2ClientsTreeItem extends vscode.TreeItem {
     this.tooltip = `ClientID: ${oauth2.clientID}\nClientSecret: ${oauth2.clientSecret}\nGrant Types: ${oauth2.grantTypes}\nScope: ${oauth2.scope}\nAudience: ${oauth2.audience}\nRedirect URIS: ${oauth2.redirectUris}\nResponse Type: ${oauth2.responseType}`;
     this.iconPath = this.getIconPath(oauth2.clientID);
     this._item = this.oauth2;
-    this.contextValue = "oauth2Clients";
+    this.contextValue = 'oauth2Clients';
   }
 
   private getIconPath(clientID: string): vscode.ThemeIcon | undefined {

--- a/src/tree/listProjects.ts
+++ b/src/tree/listProjects.ts
@@ -66,7 +66,7 @@ export class ProjectsTreeItem extends vscode.TreeItem {
     this.tooltip = `ID: ${project.id}\nSlug: ${project.slug}\nState: ${project.state}`;
     this.iconPath = this.getIconPath(project.state);
     this._item = this.project;
-    this.contextValue = "project";
+    this.contextValue = 'project';
   }
 
   public get pId(): string {

--- a/src/tree/listProjects.ts
+++ b/src/tree/listProjects.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { spawn } from 'child_process';
 import { oryCommand } from '../extension';
-import { spwanCommonErrAndClose } from '../helper';
+import { spawnCommonErrAndClose } from '../helper';
 
 export interface Project {
   id: string;
@@ -66,6 +66,7 @@ export class ProjectsTreeItem extends vscode.TreeItem {
     this.tooltip = `ID: ${project.id}\nSlug: ${project.slug}\nState: ${project.state}`;
     this.iconPath = this.getIconPath(project.state);
     this._item = this.project;
+    this.contextValue = "project";
   }
 
   public get pId(): string {
@@ -109,7 +110,7 @@ export async function runOryListProjects(): Promise<any> {
   let json: any;
 
   const listProject = spawn(oryCommand, ['list', 'projects', '--format', `${projectOutputFormat}`]);
-  await spwanCommonErrAndClose(listProject, 'Projects').then((value) => {
+  await spawnCommonErrAndClose(listProject, 'Projects').then((value) => {
     json = JSON.parse(value);
   });
   return json;

--- a/src/tree/listRelationships.ts
+++ b/src/tree/listRelationships.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { spawn } from 'child_process';
 import { oryCommand } from '../extension';
-import { spwanCommonErrAndClose } from '../helper';
+import { spawnCommonErrAndClose } from '../helper';
 
 interface TreeOutputPermission {
   subject: string;
@@ -94,8 +94,8 @@ export class ListRelationshipsProvider implements vscode.TreeDataProvider<Relati
       if (relationshipsMap.has(subject)) {
         const subjectMap = relationshipsMap.get(subject)!;
         if (subjectMap.has(relation)) {
-          const exisitingObjects = subjectMap.get(relation)!;
-          exisitingObjects.push(object);
+          const existingObjects = subjectMap.get(relation)!;
+          existingObjects.push(object);
         } else {
           subjectMap.set(relation, [object]);
         }
@@ -115,7 +115,7 @@ export class ListRelationshipsProvider implements vscode.TreeDataProvider<Relati
   }
 }
 
-class RelationshipsTreeItem extends vscode.TreeItem {
+export class RelationshipsTreeItem extends vscode.TreeItem {
   public children: RelationshipsTreeItem[];
   constructor(
     public readonly subject: string,
@@ -129,6 +129,7 @@ class RelationshipsTreeItem extends vscode.TreeItem {
     this.tooltip = tooltip ? tooltip : subject;
     this.iconPath = new vscode.ThemeIcon('references', color);
     this.children = [];
+    this.contextValue = "relationships";
   }
 
   getChildren(): RelationshipsTreeItem[] {
@@ -156,6 +157,13 @@ class RelationshipsTreeItem extends vscode.TreeItem {
     }
     return this.children;
   }
+
+  public get relationshipString(): string {
+    if (this.tooltip !== undefined) {
+      return this.tooltip;
+    }
+    return this.subject;
+  }
 }
 
 export async function runOryListRelationships(): Promise<any> {
@@ -163,7 +171,7 @@ export async function runOryListRelationships(): Promise<any> {
   let json: any;
 
   const listRelationships = spawn(oryCommand, ['list', 'relationships', '--format', `${relationshipOutputFormat}`]);
-  await spwanCommonErrAndClose(listRelationships, 'Relationships').then((value) => {
+  await spawnCommonErrAndClose(listRelationships, 'Relationships').then((value) => {
     json = JSON.parse(value);
   });
   return json;

--- a/src/tree/listRelationships.ts
+++ b/src/tree/listRelationships.ts
@@ -129,7 +129,7 @@ export class RelationshipsTreeItem extends vscode.TreeItem {
     this.tooltip = tooltip ? tooltip : subject;
     this.iconPath = new vscode.ThemeIcon('references', color);
     this.children = [];
-    this.contextValue = "relationships";
+    this.contextValue = 'relationships';
   }
 
   getChildren(): RelationshipsTreeItem[] {


### PR DESCRIPTION
Adds the delete options for identity, access-token, jwk, oauth2-client, and relationships. 

![delete options](https://github.com/ory/cli-vscode-extension/assets/35197703/5a7803d6-85b1-49e0-a90f-0c39200df00a)

Also adds the option to directly delete individual Identities and Oauth2-clients from the sidebar list option.

![image](https://github.com/ory/cli-vscode-extension/assets/35197703/8d8b6e7f-7d7f-4df2-a746-d66e3b98508f)

![image](https://github.com/ory/cli-vscode-extension/assets/35197703/1d4abec6-a1ea-4f0e-a5ed-b1c30498bc57)

And all the CLI flag options are also in the form of checkboxes. Below is an example of how, while deleting relationships, it asks for flags. Also shows a warning to use --force and shows affecting tuples if the --force flag isn't used. 

![image](https://github.com/ory/cli-vscode-extension/assets/35197703/e9db7c85-f796-4f47-89ba-4fe4e92e0006)
