### PR TITLE
Feat: Patch Command

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,17 @@
           "group": "navigation@1"
         },
         {
+          "command": "ory.projects.patchConfig",
+          "when": "view == listProjects"
+        },
+        {
           "command": "ory.identities.refresh",
           "when": "view == listIdentities",
           "group": "navigation@1"
+        },
+        {
+          "command": "ory.identities.patchConfig",
+          "when": "view == listIdentities"
         },
         {
           "command": "ory.oauth2clients.refresh",
@@ -32,9 +40,21 @@
           "group": "navigation@1"
         },
         {
+          "command": "ory.oauth2clients.patchConfig",
+          "when": "view == listOauth2Clients"
+        },
+        {
           "command": "ory.relationships.refresh",
           "when": "view == listRelationships",
           "group": "navigation@1"
+        },
+        {
+          "command": "ory.relationships.patchConfig",
+          "when": "view == listRelationships"
+        },
+        {
+          "command": "ory.relationships.patchOPL",
+          "when": "view == listRelationships"
         }
       ],
       "view/item/context": [
@@ -248,6 +268,30 @@
       {
         "command": "ory.create",
         "title": "Ory: Create"
+      },
+      {
+        "command": "ory.patch",
+        "title": "Ory: Patch"
+      },
+      {
+        "command": "ory.identities.patchConfig",
+        "title": "Patch Config"
+      },
+      {
+        "command": "ory.oauth2clients.patchConfig",
+        "title": "Patch Config"
+      },
+      {
+        "command": "ory.projects.patchConfig",
+        "title": "Patch Config"
+      },
+      {
+        "command": "ory.relationships.patchConfig",
+        "title": "Patch Config"
+      },
+      {
+        "command": "ory.relationships.patchOPL",
+        "title": "Patch OPL"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,14 @@ import { ListOauth2ClientsProvider, Oauth2ClientsTreeItem } from './tree/listOau
 import { ListRelationshipsProvider, RelationshipsTreeItem } from './tree/listRelationships';
 import { runOryDelete } from './oryDelete';
 import { runOryCreate } from './oryCreate';
+import {
+  oryPatchIdentityConfig,
+  oryPatchOAuth2Config,
+  oryPatchOPL,
+  oryPatchPermissionConfig,
+  oryPatchProject,
+  runOryPatch
+} from './oryPatch';
 
 export const outputChannel = vscode.window.createOutputChannel('Ory');
 
@@ -75,9 +83,15 @@ export async function activate(context: vscode.ExtensionContext) {
   registerCommand('ory.version', () => runOryVersion(), context);
   registerCommand('ory.activate', () => vscode.window.showInformationMessage('Ory is activated'), context);
   registerCommand('ory.promptforinstall', () => offerToInstallOry(), context);
+
+  // Auth Command
   registerCommand('ory.auth', () => runOryAuth(), context);
   registerCommand('ory.auth.logout', () => runOryAuthLogout(), context);
+
+  // Create Command
   registerCommand('ory.create', () => runOryCreate(), context);
+
+  // Use Command
   registerCommand('ory.use', () => runOryUse(), context);
   registerCommand(
     'ory.use.project',
@@ -88,6 +102,8 @@ export async function activate(context: vscode.ExtensionContext) {
     },
     context
   );
+
+  // Copy Command
   registerCommand(
     'ory.copy.projectId',
     (node?: ProjectsTreeItem) => {
@@ -99,6 +115,32 @@ export async function activate(context: vscode.ExtensionContext) {
     },
     context
   );
+  registerCommand(
+    'ory.copy.identityID',
+    async (node?: IdentitiesTreeItem) => {
+      console.log(node?.iId);
+      if (node !== undefined) {
+        vscode.env.clipboard
+          .writeText(node.iId)
+          .then(() => vscode.window.showInformationMessage('Copied to clipboard!'));
+      }
+    },
+    context
+  );
+  registerCommand(
+    'ory.copy.relationshipString',
+    async (node?: RelationshipsTreeItem) => {
+      console.log(node?.relationshipString);
+      if (node !== undefined) {
+        vscode.env.clipboard
+          .writeText(node.relationshipString)
+          .then(() => vscode.window.showInformationMessage('Copied to clipboard!'));
+      }
+    },
+    context
+  );
+
+  // Get Command
   registerCommand('ory.get', () => runOryGet(), context);
   registerCommand(
     'ory.get.projectConfig',
@@ -183,30 +225,8 @@ export async function activate(context: vscode.ExtensionContext) {
     },
     context
   );
-  registerCommand(
-    'ory.copy.identityID',
-    async (node?: IdentitiesTreeItem) => {
-      console.log(node?.iId);
-      if (node !== undefined) {
-        vscode.env.clipboard
-          .writeText(node.iId)
-          .then(() => vscode.window.showInformationMessage('Copied to clipboard!'));
-      }
-    },
-    context
-  );
-  registerCommand(
-    'ory.copy.relationshipString',
-    async (node?: RelationshipsTreeItem) => {
-      console.log(node?.relationshipString);
-      if (node !== undefined) {
-        vscode.env.clipboard
-          .writeText(node.relationshipString)
-          .then(() => vscode.window.showInformationMessage('Copied to clipboard!'));
-      }
-    },
-    context
-  );
+
+  // Delete Command
   registerCommand('ory.delete', () => runOryDelete(), context);
   registerCommand(
     'ory.delete.identity',
@@ -226,6 +246,51 @@ export async function activate(context: vscode.ExtensionContext) {
         listOauth2ClientsProvider.delete(node.clientID);
       }
     },
+    context
+  );
+
+  // Patch Command
+  registerCommand('ory.patch', () => runOryPatch(), context);
+  registerCommand(
+    'ory.identities.patchConfig',
+    () =>
+      oryPatchIdentityConfig({
+        label: 'identity-config',
+        description: 'Patch the Ory Identities configuration of the defined Ory Network project.'
+      }),
+    context
+  );
+  registerCommand(
+    'ory.oauth2clients.patchConfig',
+    () => {
+      oryPatchOAuth2Config({
+        label: 'oauth2-config',
+        description: 'Patch the Ory OAuth2 & OpenID Connect configuration of the specified Ory Network project.'
+      });
+    },
+    context
+  );
+  registerCommand(
+    'ory.relationships.patchConfig',
+    () =>
+      oryPatchPermissionConfig({
+        label: 'permission-config',
+        description: 'Patch the Ory Permissions configuration of the specified Ory Network project.'
+      }),
+    context
+  );
+  registerCommand(
+    'ory.projects.patchConfig',
+    () =>
+      oryPatchProject({
+        label: 'project',
+        description: 'Patch the Ory Network project configuration.'
+      }),
+    context
+  );
+  registerCommand(
+    'ory.relationships.patchOPL',
+    () => oryPatchOPL({ label: 'opl', description: 'Update the Ory Permission Language file in Ory Network.' }),
     context
   );
   context.subscriptions.push(projectView, identityView, oauth2ClientsView, relationshipsView);

--- a/src/helper/index.ts
+++ b/src/helper/index.ts
@@ -79,7 +79,12 @@ export function webViewPanel(viewType: string, title: string, showOptions: vscod
   panel.webview.html = htmlContent;
 }
 
-export async function commandInput(obj: { label: string; description: string; type: string; useLabelPlaceHolder?: boolean; }): Promise<string[]> {
+export async function commandInput(obj: {
+  label: string;
+  description: string;
+  type: string;
+  useLabelPlaceHolder?: boolean;
+}): Promise<string[]> {
   let resultString: string[] = [];
   let input: string | undefined;
   if (obj.type === 'empty') {
@@ -108,4 +113,24 @@ export async function commandInput(obj: { label: string; description: string; ty
   }
 
   return resultString;
+}
+
+export async function fileType(cmd: string): Promise<string> {
+  const formatInput = await vscode.window.showQuickPick(
+    [{ label: 'json', picked: true }, { label: 'yaml/yml' }, { label: 'url' }, { label: 'base64' }],
+    { title: `${cmd} format`, placeHolder: 'Set the output format', ignoreFocusOut: true }
+  );
+  if (formatInput === undefined) {
+    return 'noUploadTypeSelected';
+  }
+  switch (formatInput?.label) {
+    case 'yaml/yml':
+      return 'yaml';
+    case 'url':
+      return 'url';
+    case 'base64':
+      return 'base64';
+    default:
+      return 'json';
+  }
 }

--- a/src/oryPatch.ts
+++ b/src/oryPatch.ts
@@ -1,0 +1,221 @@
+import * as vscode from 'vscode';
+import { spawn } from 'child_process';
+import { oryCommand } from './extension';
+import { spawnCommonErrAndClose, fileType } from './helper';
+
+export async function runOryPatch() {
+  const result = await vscode.window.showQuickPick([
+    {
+      label: 'identity-config',
+      description: 'Patch the Ory Identities configuration of the defined Ory Network project.',
+      type: 'string'
+    },
+    {
+      label: 'oauth2-config',
+      description: 'Patch the Ory OAuth2 & OpenID Connect configuration of the specified Ory Network project.',
+      type: 'string'
+    },
+    {
+      label: 'permission-config',
+      description: 'Patch the Ory Permissions configuration of the specified Ory Network project.',
+      type: 'string'
+    },
+    {
+      label: 'project',
+      description: 'Patch the Ory Network project configuration.',
+      type: 'string'
+    },
+    {
+      label: 'opl',
+      description: 'Update the Ory Permission Language file in Ory Network.',
+      type: 'string'
+    }
+  ]);
+
+  switch (result?.label) {
+    case 'identity-config':
+      await oryPatchIdentityConfig(result);
+      break;
+    case 'oauth2-config':
+      await oryPatchOAuth2Config(result);
+      break;
+    case 'permission-config':
+      await oryPatchPermissionConfig(result);
+      break;
+    case 'project':
+      await oryPatchProject(result);
+      break;
+    case 'opl':
+      await oryPatchOPL(result);
+      break;
+  }
+}
+export async function oryPatchIdentityConfig(result: vscode.QuickPickItem) {
+  const identityInputs = await commandInput(result);
+  if (identityInputs === undefined) {
+    return;
+  }
+  console.log(identityInputs);
+  const command = commandBuilder(identityInputs);
+
+  const patchIdentityConfig = spawn(oryCommand, ['patch', 'identity-config', identityInputs.projectID, ...command]);
+
+  await spawnCommonErrAndClose(patchIdentityConfig, 'identity-config', '');
+  return;
+}
+
+export async function oryPatchOAuth2Config(result: vscode.QuickPickItem) {
+  const oauth2ConfigInputs = await commandInput(result);
+  if (oauth2ConfigInputs === undefined) {
+    return;
+  }
+  console.log(oauth2ConfigInputs);
+  const command = commandBuilder(oauth2ConfigInputs);
+
+  const patchOAuth2Config = spawn(oryCommand, ['patch', 'oauth2-config', oauth2ConfigInputs.projectID, ...command]);
+
+  await spawnCommonErrAndClose(patchOAuth2Config, 'oauth2-config', '');
+  return;
+}
+
+export async function oryPatchProject(result: vscode.QuickPickItem) {
+  const projectInputs = await commandInput(result);
+  if (projectInputs === undefined) {
+    return;
+  }
+  console.log(projectInputs);
+  const command = commandBuilder(projectInputs);
+
+  const patchProject = spawn(oryCommand, ['patch', 'project', projectInputs.projectID, ...command]);
+
+  await spawnCommonErrAndClose(patchProject, 'project', '');
+  return;
+}
+
+export async function oryPatchPermissionConfig(result: vscode.QuickPickItem) {
+  const permissionConfigInputs = await commandInput(result);
+  if (permissionConfigInputs === undefined) {
+    return;
+  }
+  console.log(permissionConfigInputs);
+  const command = commandBuilder(permissionConfigInputs);
+
+  const patchPermissionConfig = spawn(oryCommand, [
+    'patch',
+    'permission-config',
+    permissionConfigInputs.projectID,
+    ...command
+  ]);
+
+  await spawnCommonErrAndClose(patchPermissionConfig, 'permission-config', '');
+  return;
+}
+
+export async function oryPatchOPL(result: vscode.QuickPickItem) {
+  const oplInputs = await commandInput(result);
+  if (oplInputs === undefined) {
+    return;
+  }
+  console.log(oplInputs);
+  const command = commandBuilder(oplInputs);
+
+  const patchOPL = spawn(oryCommand, ['patch', 'opl', oplInputs.projectID, ...command]);
+
+  await spawnCommonErrAndClose(patchOPL, 'opl', '');
+  return;
+}
+
+function commandBuilder(input: { [key: string]: string }) {
+  let stringBuilder: string[] = [];
+  for (const key in input) {
+    if (key === 'projectID') {
+      continue;
+    }
+    stringBuilder.push('--' + key + '=' + input[key]);
+  }
+  return stringBuilder;
+}
+
+async function commandInput(result: vscode.QuickPickItem) {
+  const options = await vscode.window.showQuickPick(
+    [
+      { label: 'add', description: 'Add a specific key to the configuration' },
+      { label: 'remove', description: 'Remove a specific key from the configuration' },
+      { label: 'replace', description: 'Replace a specific key in the configuration' },
+      { label: 'file', description: 'Configuration file(s) to update the project' }
+    ],
+    {
+      title: `Patch ${result.label} Options`,
+      placeHolder: 'options...',
+      canPickMany: true,
+      ignoreFocusOut: true
+    }
+  );
+
+  if (options === undefined) {
+    return;
+  }
+
+  const flagDataJson: { [key: string]: string } = {};
+
+  let projectID = await vscode.window.showInputBox({
+    title: `Patch ${result.label} of which project?`,
+    placeHolder: 'project ID',
+    ignoreFocusOut: true
+  });
+
+  if (projectID === undefined) {
+    return;
+  }
+  flagDataJson['projectID'] = `${projectID}`;
+
+  for (const option of options) {
+    if (option.label === 'file') {
+      const fileTypeInput = await fileType(`Ory Patch ${result.label}`);
+      if (fileTypeInput === 'noUploadTypeSelected') {
+        return;
+      }
+
+      if (fileTypeInput === 'yaml/yml' || fileTypeInput === 'json') {
+        const fileLocation = await vscode.window.showOpenDialog({
+          title: `Ory Patch ${result.label}`,
+          filters: {
+            yaml: ['yaml', 'yml'],
+            json: ['json']
+          },
+          canSelectMany: false
+        });
+
+        if (fileLocation === undefined) {
+          return;
+        }
+        flagDataJson[option.label] = `${fileLocation[0].fsPath}`;
+      } else {
+        // take input for base64 and url
+        const base64OrURLPrefix = fileTypeInput === 'url' ? 'https://example.org/config.yaml' : 'base64://<json>';
+        const configURL = await vscode.window.showInputBox({
+          title: `Ory Patch ${result.label}`,
+          placeHolder: `Enter ${base64OrURLPrefix}`,
+          ignoreFocusOut: true
+        });
+
+        if (configURL === undefined) {
+          return;
+        }
+
+        flagDataJson[option.label] = configURL;
+      }
+    } else {
+      const val = (await vscode.window.showInputBox({
+        title: `Ory Patch ${result.label}`,
+        prompt: `${option.description}`,
+        placeHolder: '/selfservice/methods/password/enabled=false',
+        ignoreFocusOut: true
+      }))!;
+      if (val) {
+        flagDataJson[option.label] = val;
+      }
+    }
+  }
+  return flagDataJson;
+}


### PR DESCRIPTION
This adds the patch command with the `add, replace, remove, file` flag for the below sub-commands:

- [x] identity-config
- [x] oauth2-config
- [x] opl
- [x] permission-config
- [x] project

![image](https://github.com/ory/cli-vscode-extension/assets/35197703/5b3af2ba-27b8-4024-b234-3e241ed02464)
![image](https://github.com/ory/cli-vscode-extension/assets/35197703/41583b6a-f122-401a-8b4e-d3156a904f49)
![image](https://github.com/ory/cli-vscode-extension/assets/35197703/902fdb10-8541-4b73-9bca-38a191cf9f79)
