### PR TITLE
feat: tunnel command

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
           "command": "ory.relationships.refresh",
           "when": "view == listRelationships",
           "group": "navigation@1"
+        },
+        {
+          "command": "ory.tunnel.refresh",
+          "when": "view == listRunningProcesses",
+          "group": "navigation@1"
         }
       ],
       "view/item/context": [
@@ -102,6 +107,11 @@
           "command": "ory.delete.oauth2Client",
           "when": "view == listOauth2Clients && viewItem == oauth2Clients",
           "group": "inline"
+        },
+        {
+          "command": "ory.tunnel.stopProcess",
+          "when": "view == listRunningProcesses && viewItem == runningProcess",
+          "group": "inline"
         }
       ]
     },
@@ -131,6 +141,10 @@
         {
           "id": "listRelationships",
           "name": "Relationships"
+        },
+        {
+          "id": "listRunningProcesses",
+          "name": "Tunnel Running Processes"
         }
       ]
     },
@@ -222,6 +236,16 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "ory.tunnel.refresh",
+        "title": "Refresh",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "ory.tunnel.stopProcess",
+        "title": "Stop Process",
+        "icon": "$(debug-stop)"
+      },
+      {
         "command": "ory.copy.relationshipString",
         "title": "Copy Relationship String"
       },
@@ -248,6 +272,10 @@
       {
         "command": "ory.create",
         "title": "Ory: Create"
+      },
+      {
+        "command": "ory.tunnel",
+        "title": "Ory: Tunnel"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,8 +20,10 @@ import { runOryUse, runOryUseProject } from './oryUse';
 import { IdentitiesTreeItem, ListIdentitiesProvider } from './tree/listIdentities';
 import { ListOauth2ClientsProvider, Oauth2ClientsTreeItem } from './tree/listOauth2Clients';
 import { ListRelationshipsProvider, RelationshipsTreeItem } from './tree/listRelationships';
+import { ListRunningProcessProvider, RunningProcessTreeItem } from './tree/listTunnelProcess';
 import { runOryDelete } from './oryDelete';
 import { runOryCreate } from './oryCreate';
+import { runOryTunnel } from './oryTunnel';
 
 export const outputChannel = vscode.window.createOutputChannel('Ory');
 
@@ -69,6 +71,14 @@ export async function activate(context: vscode.ExtensionContext) {
   const relationshipsView = vscode.window.createTreeView('listRelationships', {
     treeDataProvider: listRelationshipsProvider,
     showCollapseAll: true
+  });
+
+  // Tunnel list
+  const listRunningProcessProvider = new ListRunningProcessProvider();
+  vscode.window.registerTreeDataProvider('listRunningProcesses', listRunningProcessProvider);
+  registerCommand('ory.tunnel.refresh', () => listRunningProcessProvider.refresh(), context);
+  const tunnelView = vscode.window.createTreeView('listRunningProcesses', {
+    treeDataProvider: listRunningProcessProvider
   });
 
   registerCommand('ory.helloWorld', () => vscode.window.showInformationMessage('Hello World from ory!'), context);
@@ -224,6 +234,18 @@ export async function activate(context: vscode.ExtensionContext) {
       console.log(node?.clientID);
       if (node !== undefined) {
         listOauth2ClientsProvider.delete(node.clientID);
+      }
+    },
+    context
+  );
+
+  registerCommand('ory.tunnel', () => runOryTunnel(listRunningProcessProvider), context);
+  registerCommand(
+    'ory.tunnel.stopProcess',
+    async (node?: RunningProcessTreeItem) => {
+      console.log(node?.runningPS.processName);
+      if (node !== undefined) {
+        listRunningProcessProvider.remove(node.runningPS.id);
       }
     },
     context

--- a/src/oryTunnel.ts
+++ b/src/oryTunnel.ts
@@ -1,0 +1,178 @@
+import * as vscode from 'vscode';
+import { spawn } from 'child_process';
+import { oryCommand } from './extension';
+import { spawnCommonErrAndClose } from './helper';
+import { ListRunningProcessProvider, RunningProcess } from './tree/listTunnelProcess';
+
+export async function runOryTunnel(listRunningProcesses: ListRunningProcessProvider) {
+  const result = await vscode.window.showQuickPick(
+    [
+      {
+        label: 'allowed-cors-origins',
+        description:
+          'A list of allowed CORS origins. Wildcards are allowed. For multiple application urls add it as comma (,) separated.'
+      },
+      {
+        label: 'cookie-domain',
+        description: `Set a dedicated cookie domain.`
+      },
+      {
+        label: 'debug',
+        description: 'Use this flag to debug, for example, CORS requests.'
+      },
+      {
+        label: 'default-redirect-url',
+        description: `Set the URL to redirect to per default after e.g. login or account creation.`
+      },
+      {
+        label: 'dev',
+        description: 'Use this flag when developing locally.'
+      },
+      {
+        label: 'port',
+        description: 'The port the proxy should listen on. (default 4000)'
+      },
+      {
+        label: 'project',
+        description: 'The slug of your Ory Network project.'
+      },
+      {
+        label: 'None',
+        description: 'None. skip these options.',
+        picked: true
+      }
+    ],
+    {
+      placeHolder: 'Pick to options...',
+      title: 'Ory Tunnel',
+      ignoreFocusOut: true,
+      canPickMany: true
+    }
+  );
+
+  if (result === undefined) {
+    return;
+  }
+
+  let name = await vscode.window.showInputBox({
+    title: 'Name',
+    placeHolder: 'Name',
+    ignoreFocusOut: true
+  });
+
+  if (name === undefined) {
+    vscode.window.showWarningMessage('Name is required');
+    return;
+  }
+
+  let projectID = await vscode.window.showInputBox({
+    title: 'Project ID',
+    placeHolder: 'Project ID',
+    ignoreFocusOut: true
+  });
+
+  if (projectID === undefined) {
+    return;
+  }
+
+  const flagDataJson: { [key: string]: string } = {};
+
+  const applicationURLs = await vscode.window.showInputBox({
+    title: 'Application URLs',
+    placeHolder: 'Application URLs',
+    prompt: 'For multiple application urls add it as comma (,) separated',
+    ignoreFocusOut: true
+  });
+
+  if (applicationURLs === undefined) {
+    return;
+  }
+
+  flagDataJson['application-urls'] = applicationURLs.replace(/\s/g, '');
+
+  for (const option of result) {
+    if (option.label === 'None' || option.label === 'project') {
+      continue;
+    } else if (option.label === 'dev' || option.label === 'debug') {
+      flagDataJson[option.label] = 'true';
+    } else {
+      console.log(option.label);
+      await vscode.window
+        .showInputBox({
+          title: option.label,
+          placeHolder: option.label,
+          prompt: option.description,
+          ignoreFocusOut: true
+        })
+        .then((val) => {
+          if (val === undefined) {
+            return;
+          }
+          flagDataJson[option.label] = val.replace(/\s/g, '');
+        });
+    }
+  }
+
+  let stringBuilder: string[] = [];
+  for (const key in flagDataJson) {
+    if (key === 'None') {
+      continue;
+    }
+    if (key === 'dev' || key === 'debug') {
+      stringBuilder.push(`--${key}`);
+      continue;
+    }
+
+    if (key === 'application-urls') {
+      for (const url of processCommaSeparatedToArray(flagDataJson[key])) {
+        stringBuilder.push(`${url}`);
+      }
+      continue;
+    }
+
+    if (key === 'allowed-cors-origins') {
+      for (const url of processCommaSeparatedToArray(flagDataJson[key])) {
+        stringBuilder.push(`--${key}=${url}`);
+      }
+      continue;
+    }
+    stringBuilder.push(`--${key}=${flagDataJson[key]}`);
+  }
+
+  const tunnelToken = spawn(oryCommand, ['tunnel', `--project=${projectID}`, ...stringBuilder]);
+
+  let pid: string;
+  if (tunnelToken.pid === undefined) {
+    pid = makeId(10);
+  } else {
+    pid = `${tunnelToken.pid}`;
+  }
+  const tunnelProcess: RunningProcess = {
+    id: pid,
+    command: 'tunnel',
+    status: 'running',
+    process: tunnelToken,
+    processName: name
+  };
+
+  listRunningProcesses.add(tunnelProcess);
+}
+
+function processCommaSeparatedToArray(input: string | undefined): string[] {
+  if (input === undefined) {
+    return [];
+  }
+  return input.split(',');
+}
+
+function makeId(length: number) {
+  let result = '';
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const charactersLength = characters.length;
+  let counter = 0;
+  while (counter < length) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    counter += 1;
+  }
+  return result;
+}

--- a/src/tree/listTunnelProcess.ts
+++ b/src/tree/listTunnelProcess.ts
@@ -56,7 +56,7 @@ export class RunningProcessTreeItem extends vscode.TreeItem {
   constructor(public readonly runningPS: RunningProcess) {
     super(runningPS.processName, vscode.TreeItemCollapsibleState.None);
 
-    this.tooltip = `Process: ${runningPS.id}`;
+    this.tooltip = `Process: ${runningPS.id}\nApplication: ${runningPS.processName}`;
     this.iconPath = this.getIconPath(runningPS.status);
     this._item = runningPS;
     this.contextValue = 'runningProcess';

--- a/src/tree/listTunnelProcess.ts
+++ b/src/tree/listTunnelProcess.ts
@@ -1,0 +1,80 @@
+import * as vscode from 'vscode';
+import { ChildProcessWithoutNullStreams } from 'child_process';
+
+// Define a data structure for a running process
+export interface RunningProcess {
+  id: string;
+  command: string;
+  status: 'running' | 'paused' | 'stopped';
+  process: ChildProcessWithoutNullStreams;
+  processName: string;
+}
+
+// Provider class for the tree view
+export class ListRunningProcessProvider implements vscode.TreeDataProvider<RunningProcessTreeItem> {
+  private topLevelItems: RunningProcessTreeItem[] = [];
+  private _onDidChangeTreeData: vscode.EventEmitter<
+    RunningProcessTreeItem | RunningProcessTreeItem[] | undefined | void
+  > = new vscode.EventEmitter<RunningProcessTreeItem | RunningProcessTreeItem[] | undefined | void>();
+  readonly onDidChangeTreeData?: vscode.Event<
+    RunningProcessTreeItem | RunningProcessTreeItem[] | undefined | void | null
+  > = this._onDidChangeTreeData.event;
+
+  getTreeItem(element: RunningProcessTreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
+    return element;
+  }
+
+  getChildren(element?: RunningProcessTreeItem): vscode.ProviderResult<RunningProcessTreeItem[]> {
+    if (!element) {
+      return this.topLevelItems;
+    }
+    return [];
+  }
+
+  // Add methods to start and kill processes
+  add(process: RunningProcess) {
+    this.topLevelItems.push(new RunningProcessTreeItem(process));
+    this._onDidChangeTreeData.fire();
+  }
+
+  remove(id: string) {
+    const index = this.topLevelItems.findIndex((item) => item.runningPS.id === id);
+    if (index !== -1) {
+      this.topLevelItems[index].runningPS.process.kill();
+      this.topLevelItems.splice(index, 1);
+      this._onDidChangeTreeData.fire();
+    }
+  }
+
+  refresh() {
+    this._onDidChangeTreeData.fire();
+  }
+}
+
+export class RunningProcessTreeItem extends vscode.TreeItem {
+  private _item: RunningProcess;
+  constructor(public readonly runningPS: RunningProcess) {
+    super(runningPS.processName, vscode.TreeItemCollapsibleState.None);
+
+    this.tooltip = `Process: ${runningPS.id}`;
+    this.iconPath = this.getIconPath(runningPS.status);
+    this._item = runningPS;
+    this.contextValue = 'runningProcess';
+  }
+
+  private getIconPath(status: string): vscode.ThemeIcon | undefined {
+    let icon: vscode.ThemeIcon;
+    switch (status) {
+      case 'paused':
+        icon = new vscode.ThemeIcon('debug-pause', new vscode.ThemeColor('debugIcon.pauseForeground'));
+        break;
+      case 'stopped':
+        icon = new vscode.ThemeIcon('debug-stop', new vscode.ThemeColor('debugIcon.stopForeground'));
+        break;
+      default:
+        icon = new vscode.ThemeIcon('debug-disconnect', new vscode.ThemeColor('debugIcon.startForeground'));
+        break;
+    }
+    return icon;
+  }
+}


### PR DESCRIPTION
With the tunnel command, we can run multiple tunnels at the same time.

The list of running tunnels will be shown on the right-side panel of VS Code with the stop option. When we close the VS Code, all the running tunnel will get terminated. On the next start of VS Code, they will not start again because there is no state-storing mechanism.

On hover, we can see the pid and application name for which the process is running.
![image](https://github.com/ory/cli-vscode-extension/assets/35197703/bfd49169-faaf-443f-84b0-0d8ced2fc6d8)


Flag option in vs code:
![image](https://github.com/ory/cli-vscode-extension/assets/35197703/40b985af-ea66-4849-8baa-e293d66bd2a1)
